### PR TITLE
Treat ❡ as incond, can appear next to words without space between

### DIFF
--- a/tools/tokenisers/tokeniser-disamb-gt-desc.pmscript
+++ b/tools/tokenisers/tokeniser-disamb-gt-desc.pmscript
@@ -35,7 +35,7 @@ Define inputmark    [ 0:"@PMATCH_INPUT_MARK@" | 0:"@PMATCH_BACKTRACKING@" ];
 Define incondform      Punct|
                        {„}|{“}|{”}|{…}|{‚}|{‘}|{’}|
                        {–}|{—}|{­}|{_}|{<}|{>}|{«}|{»}|
-                       {@}|{'}|{‹}|{›}|{➤}|{•}|{﻿} ;
+                       {@}|{'}|{‹}|{›}|{➤}|{•}|{﻿}|{❡} ;
 
 !! Whitespace contains ASCII white space and
 !! the List contains some unicode white space characters


### PR DESCRIPTION
might fix https://github.com/giellalt/lang-sme/issues/501