### PR TITLE
&typo → typo early in file, finally only &typo if no other errors

### DIFF
--- a/tools/grammarcheckers/grammarchecker.cg3
+++ b/tools/grammarcheckers/grammarchecker.cg3
@@ -1246,7 +1246,7 @@ LIST &syn-váccii = &syn-váccii ;
 LIST &syn-vkan-not-vkán = &syn-vkan-not-vkán ;
 LIST &syn-vkan-not-vkán2 = &syn-vkan-not-vkán2 ;
 LIST &syn-wrong-transitivity = &syn-wrong-transitivity ;
-LIST &typo = &typo ;
+LIST typo = typo ;
 
 
 LIST &msyn-acc-to-comp = &msyn-acc-to-comp ;
@@ -14203,7 +14203,7 @@ COPY:syn-illative-agent-with-hallat-passive (Ill SUGGEST) EXCEPT (Loc &syn-illat
 # without further work.
 # Outcommented for now, until we have decided which approach to take
 # (this one, or the one below, with multiple, targeted cg rules).
-# SELECT:PunctErrOrth Err/Orth IF (0 (PUNCT))(NOT 0 (&typo))  ;
+# SELECT:PunctErrOrth Err/Orth IF (0 (PUNCT))(NOT 0 (typo))  ;
 
 #1. Mun lean dáppe." Son ii leat --- dáppe.“
 #2. Mun lean dáppe. " Son ii leat -- “
@@ -14675,10 +14675,10 @@ SELECT:PcleCompounds Adv IF (1 ("ge")) (0 (Adv Err/Orth-a-á));
 # Please leave as is until the leak has been fixed by Tino.
 # NOT &LINK so we don't remove readings meant to stretch the squiggly underline of other cohort errors
 
-#REMOVE:SuperfluousErrTags SUB:0 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (&typo)) ;
-REMOVE:SuperfluousErrTags SUB:1 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (&typo)) ;
-REMOVE:SuperfluousErrTags SUB:2 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (&typo)) ;
-REMOVE:SuperfluousErrTags SUB:3 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (&typo)) ;
+#REMOVE:SuperfluousErrTags SUB:0 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (typo)) ;
+REMOVE:SuperfluousErrTags SUB:1 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (typo)) ;
+REMOVE:SuperfluousErrTags SUB:2 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (typo)) ;
+REMOVE:SuperfluousErrTags SUB:3 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorTags) (NOT 0 (&LINK)) (NOT 0 (typo)) ;
 
     # Fallback rules for the remaining errors
     # ---------------------------------------
@@ -14692,15 +14692,15 @@ REMOVE:SuperfluousErrTags SUB:3 AllErrorTags IF (0/* AllErrorTags) (0/* NoErrorT
 # TODO: Different error tag for these? Currently the same as dynamically <spelled> errors.
 
 # Speller suggestions rule - make sure the suggestions survive the cg mangling:
-ADD:spelled (&typo SUGGESTWF) (<spelled>) IF (NEGATE -1 ("”") OR (""") OR ("“") OR ("”") OR ("„") OR ("‟") LINK 2 ("”") OR (""")) ;
+ADD:spelled (typo SUGGESTWF) (<spelled>) IF (NEGATE -1 ("”") OR (""") OR ("“") OR ("”") OR ("„") OR ("‟") LINK 2 ("”") OR (""")) ;
 
 	#### Err/Orth rules - make sure all Err/Orth analyses are generated as the normative counterpart of itself:
-	# 1. Add a &typo error tag if there is an Err/Orth tag __anywhere__ - including in subreadings:
+	# 1. Add a typo error tag if there is an Err/Orth tag __anywhere__ - including in subreadings:
 
 
 SET NonErr/Orth = (*) - Err/Orth-any ;
 
-ADD:Err/Orth-any (&typo) TARGET (*) IF (NEGATE 0/* NonErr/Orth - Err/Lex - Err/Spellrelax)(0/* Err/Orth-any OR Err/Spellrelax)(NEGATE -1 ("”") LINK 2 ("”")) ;
+ADD:Err/Orth-any (typo) TARGET (*) IF (NEGATE 0/* NonErr/Orth - Err/Lex - Err/Spellrelax)(0/* Err/Orth-any OR Err/Spellrelax)(NEGATE -1 ("”") LINK 2 ("”")) ;
 	#$ Dávjá dát sátni unnut geavahuvvo dalle go galggašii hállat geahppáneami birra ( mii dieđusge fas lea áibbas eará go {geahppun} ).
 	## Dan sadjái bealalaččat leat diktan márkánságaid leavvat, ja dainna lágiin ráŋggaštan dárbbašmeahttumiid.
 	## Girkoválggain  čakčamánu  18.  b.  don  válljet  gosa  Ruoŧa  girku  galgá  bidjat  fámu  lagamuš  njeallje  jagi.  Geasa  attát luohttamuša?
@@ -14709,14 +14709,14 @@ ADD:Err/Orth-any (&typo) TARGET (*) IF (NEGATE 0/* NonErr/Orth - Err/Lex - Err/S
 
 	# 2. Copy to a new reading minus Err/Orth, to generate suggestions - main reading:
 
-COPY:Err/Orth-any (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (&typo) IF (NOT 0/* (SUGGESTWF) OR (SUGGEST));
+COPY:Err/Orth-any (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (typo) IF (NOT 0/* (SUGGESTWF) OR (SUGGEST));
 
-COPY:Err/Orth-any SUB:0 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (&typo) IF (NOT 0/* (SUGGESTWF) OR (SUGGEST));
+COPY:Err/Orth-any SUB:0 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (typo) IF (NOT 0/* (SUGGESTWF) OR (SUGGEST));
 
-COPY:Err/Orth-any SUB:1 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (&typo) IF (NOT 0/* (SUGGESTWF) OR (SUGGEST));
-COPY:Err/Orth-any SUB:2 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (&typo) IF (NOT 0/* (SUGGESTWF));
-COPY:Err/Orth-any SUB:3 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (&typo) IF (NOT 0/* (SUGGESTWF));
-COPY:Err/Orth-any SUB:4 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (&typo) IF (NOT 0/* (SUGGESTWF));
+COPY:Err/Orth-any SUB:1 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (typo) IF (NOT 0/* (SUGGESTWF) OR (SUGGEST));
+COPY:Err/Orth-any SUB:2 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (typo) IF (NOT 0/* (SUGGESTWF));
+COPY:Err/Orth-any SUB:3 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (typo) IF (NOT 0/* (SUGGESTWF));
+COPY:Err/Orth-any SUB:4 (SUGGEST) EXCEPT Err/Orth-any_OR_TV_IV TARGET (typo) IF (NOT 0/* (SUGGESTWF));
 	#THIS does not work at the moment, but hopefully Tino can help
 
 # 3. Substitute Err/Orth in subreadings to get something for generation.
@@ -14787,23 +14787,23 @@ COPY:Err/Orth (SUGGEST) EXCEPT (Ex/N Ex/V Ex/A Ex/IV Ex/TV Err/Orth)
                              OR (Err/Orth-a-á)
                              OR (Err/Orth-nom-acc)
                              OR (Err/Orth-nom-gen)
-                         TARGET (Err/Orth &typo)
-                             OR (Err/Orth-a-á &typo)
-                             OR (Err/Orth-nom-acc &typo)
-                             OR (Err/Orth-nom-gen &typo)
+                         TARGET (Err/Orth typo)
+                             OR (Err/Orth-a-á typo)
+                             OR (Err/Orth-nom-acc typo)
+                             OR (Err/Orth-nom-gen typo)
                          IF (NOT 0 (SUGGEST) ) ;
 	#$ Muhto dalle gártá maiddái {čielgaseappon} man_láhkái mearrideaddjit stuorát servvodagas, go sin fápmu lea gártan dego semeantan, dagahit láhttenvuođu muhtinlágan eahpealbma bivdui ja gilvui, gos vel diehta ge gártá hiŋgálastojuvvot dego čájáhussan meassuin ja eiseválddiid bušeahtain.
 	#$ Ii buot dáfus gal, muhto juste das {mainna lágiin} olmmoš láhtte ja makkár gova čájeha earáide lei sutnje hui deaŧalaš.
 
-# Fallback: Add &typo tag to any other Err tag not covered above,
+# Fallback: Add typo tag to any other Err tag not covered above,
 # to ensure that they are at least underlined - important to make the
 # grammar checker catch the same errors as the speller:
 # presently defined as:
 #  Err/Not-Orth = Err/Lex Err/DerSub Err/CmpSub Err/HyphSub Err/Hyph Err/MissingHyph Err/Spellrelax ;
-ADD:other-errors (&typo) Err/Not-Orth (NEGATE 0t (*) - Err/Any);
+ADD:other-errors (typo) Err/Not-Orth (NEGATE 0t (*) - Err/Any);
 
-# Add &typo error tag to unkown words that are not corrected by the speller, so that they at least get a blue underline and a message
-ADD:uncorrected-typos (&typo) (?) ;
+# Add typo error tag to unkown words that are not corrected by the speller, so that they at least get a blue underline and a message
+ADD:uncorrected-typos (typo) (?) ;
 
 # Local Variables:
 # cg-pre-pipe: "bash -o pipefail modes/smegram-dev9-cg.mode"
@@ -14821,3 +14821,8 @@ SUBSTITUTE (MWE) (*) TARGET MWE ;
 
 
 #SUBSTITUTE (Gram/3syll) (*) TARGET Gram/3syll ;
+
+# Only add the &typo tag if no other error tags:
+SUBSTITUTE (typo) (&typo) TARGET (typo) IF (NEGATE 0 (/^&.*/r));
+# Else drop it so it generates correctly:
+SUBSTITUTE (typo) (*) TARGET SUGGEST OR SUGGESTWF;


### PR DESCRIPTION
fix https://github.com/giellalt/lang-sme/issues/514

the typo alone gets `&typo`:
```sh
$ echo 'lobalažžan' | modes/smegram-dev.mode
"<lobalažžan>"          lobalažžan      →  lobálažžan
        "lobálaš" A Err/Orth-a-á Sem/Dummytag Ess <W:0.0> <LastCohort> <firstCohort> @HNOUN &typo
typo
        "lobálaš" A Sem/Dummytag Ess <W:0.0> <LastCohort> <firstCohort> @HNOUN SUGGEST &typo
lobálaš+A+Ess   lobálažžan
:\n
```
the complex error gets `&syn-not-dego` – with spelling errors fixed:
```
$ echo 'dego lobalažžan' | modes/smegram-dev.mode
"<dego>"
        "dego" Adv <W:0.0> <firstCohort> &LINK &syn-not-dego ID:1
:
"<lobalažžan>"          dego lobalažžan →  lobálažžan
        "lobálaš" A Err/Orth-a-á Sem/Dummytag Ess <W:0.0> <LastCohort> @COMP-CS< typo &syn-not-dego ID:2 R:DELETE1:1 R:$2:1
syn-not-dego
        "lobálaš" A Sem/Dummytag Ess <W:0.0> <LastCohort> @COMP-CS< SUGGEST &syn-not-dego ID:2 R:DELETE1:1 R:$2:1
lobálaš+A+Ess   lobálažžan
:\n
```